### PR TITLE
Sync monorepo state at "Upgrade to checkout action v4 (GHA)"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Allow goreleaser to access older tag information.
           fetch-depth: 0


### PR DESCRIPTION
Syncing from userclouds/userclouds@02d4013c5bd293f65d57fa29987f0f31618f7c86