### PR TITLE
Sync monorepo state at "ucconfig gen-manifest: omit version field from attributes"

### DIFF
--- a/internal/liveresource/liveresource.go
+++ b/internal/liveresource/liveresource.go
@@ -139,6 +139,12 @@ func MakeLiveResource(ctx context.Context, resourceType resourcetypes.ResourceTy
 			isSystem = v.Field(i).Bool()
 			continue
 		}
+		// Omit the version field from the attributes. It functions as an etag
+		// for versioned resources, and the Terraform provider won't allow it to
+		// be set
+		if jsonKey == "version" {
+			continue
+		}
 		if slices.Contains(resourceType.OmitAttributes, jsonKey) {
 			continue
 		}

--- a/internal/liveresource/liveresource_test.go
+++ b/internal/liveresource/liveresource_test.go
@@ -67,3 +67,14 @@ func TestGetLiveResourcesForType(t *testing.T) {
 		},
 	}})
 }
+
+func TestVersionAttributeOmitted(t *testing.T) {
+	res, err := MakeLiveResource(context.Background(), *resourcetypes.GetByTerraformTypeSuffix("userstore_accessor"), userstore.Accessor{
+		ID:      uuid.Must(uuid.FromString("fe20fd48-a006-4ad8-9208-4aad540d8794")),
+		Version: 7,
+		Name:    "TestAccessor",
+	})
+	assert.NoErr(t, err)
+	assert.Equal(t, res.Attributes["name"], "TestAccessor")
+	assert.Equal(t, res.Attributes["version"], nil)
+}


### PR DESCRIPTION
Syncing from userclouds/userclouds@926d515277ffc6be52a06aa34f47fdc350ed10b0