### PR TITLE
Sync monorepo state at "Upgrading to Go 1.23.1"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module userclouds.com/cmd/ucconfig
 
-go 1.22.2
+go 1.23.1
 
 require (
 	github.com/alecthomas/kong v0.9.0


### PR DESCRIPTION
Syncing from userclouds/userclouds@c09f10a45b659388693e84168adb4befe50a06b1