### PR TITLE
Sync monorepo state at "linter (and fixes) to not shadow package names with vars for readability"

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,11 +27,11 @@ type tenantConfig struct {
 }
 
 func (cfg tenantConfig) initTenantContext(ctx context.Context) tenantContext {
-	url, err := url.Parse(cfg.TenantURL)
+	tenantURL, err := url.Parse(cfg.TenantURL)
 	if err != nil {
 		uclog.Fatalf(ctx, "Failed to parse tenant URL: %v", err)
 	}
-	fqtn := strings.Split(url.Hostname(), ".")[0]
+	fqtn := strings.Split(tenantURL.Hostname(), ".")[0]
 
 	// Initialize IDP client based on env vars
 	tokenSource := jsonclient.ClientCredentialsTokenSource(cfg.TenantURL+"/oidc/token", cfg.ClientID, cfg.ClientSecret, nil)


### PR DESCRIPTION
Syncing from userclouds/userclouds@33a853f57e4139b4078617bc41a7dc75f3ba44be