### PR TITLE
Sync monorepo state at "Bump k8s.io/api from 0.32.3 to 0.33.0"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module userclouds.com/cmd/ucconfig
 
-go 1.23.1
+go 1.24.0
+
+toolchain go1.24.2
 
 require (
 	github.com/alecthomas/kong v1.10.0


### PR DESCRIPTION
Syncing from userclouds/userclouds@1865257f6217af1336f49f86b780e903e07ee8a9